### PR TITLE
Improve appEnv 'visibility' for functions running in WebbyM

### DIFF
--- a/src/Webby/Types.hs
+++ b/src/Webby/Types.hs
@@ -46,12 +46,14 @@ data WEnv env = WEnv
 -- (read-only) environment. For e.g. it can be used to store a
 -- database connection pool.
 newtype WebbyM env a = WebbyM
-  { unWebbyM :: ReaderT (WEnv env) (ResourceT IO) a
+  { unWebbyM :: ReaderT env (ReaderT (WEnv env) (ResourceT IO)) a
   }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadReader (WEnv env), Un.MonadUnliftIO)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadReader env, Un.MonadUnliftIO)
 
 runWebbyM :: WEnv w -> WebbyM w a -> IO a
-runWebbyM env = runResourceT . flip runReaderT env . unWebbyM
+runWebbyM env = runResourceT . flip runReaderT env . flip runReaderT appEnv . unWebbyM
+  where
+    appEnv = weAppEnv env
 
 -- | A route pattern represents logic to match a request to a handler.
 data RoutePattern = RoutePattern Method [Text]


### PR DESCRIPTION
With this change appEnv is only an 'ask' away. WebbyM handlers can work
with functions of the form,

  `doSomething :: (HasSomeConfig env, MonadReader env m) -> m a`

without additional boiler-plate.

A simple demonstration of this is available at `examples/Basics.hs` in this PR

Previously, since appEnv was tucked in alongside WebbyM's internal state, held
as a ReaderT environment it wasn't available through the MonadReader's 'ask'
method. This meant, for every 'appEnv', 'HasSomeConfig appEnv' combination the
library user had to define a typeclass of the following form,

  `class MonadSomeConfig m where
      getSomeConfigM :: m SomeConfig
  `

and implement the instance for 'WebbyM appEnv' which would simply fetch it from
the appEnv.