### PR TITLE
Add function to return image response

### DIFF
--- a/src/Webby.hs
+++ b/src/Webby.hs
@@ -42,6 +42,7 @@ module Webby
     text,
     stream,
     image,
+    raw,
 
     -- * Application
     mkWebbyApp,

--- a/src/Webby.hs
+++ b/src/Webby.hs
@@ -41,6 +41,7 @@ module Webby
     json,
     text,
     stream,
+    image,
 
     -- * Application
     mkWebbyApp,

--- a/src/Webby/Server.hs
+++ b/src/Webby/Server.hs
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.HashMap.Strict as H
 import qualified Data.List as L
 import qualified Data.Text as T
+import Network.Mime
 import qualified UnliftIO.Concurrent as Conc
 import qualified UnliftIO.Exception as E
 import Web.HttpApiData
@@ -127,11 +128,11 @@ finish :: WebbyM appEnv a
 finish = E.throwIO FinishThrown
 
 -- | Send an image in the response body. Also
--- sets @Content-Type@ header to @image/{imgType}
+-- sets @Content-Type@ header to @mimeType
 -- e.g. image/svg+xml
-image :: ByteString -> ByteString -> WebbyM appEnv ()
-image bs imgType = do
-  setHeader (hContentType, "image/" <> imgType)
+image :: ByteString -> MimeType -> WebbyM appEnv ()
+image bs mimeType = do
+  setHeader (hContentType, mimeType)
   raw bs
 
 -- | Send a binary stream in the response body. Also

--- a/src/Webby/Server.hs
+++ b/src/Webby/Server.hs
@@ -126,11 +126,25 @@ requestBodyLength = do
 finish :: WebbyM appEnv a
 finish = E.throwIO FinishThrown
 
+-- | Send an image in the response body. Also
+-- sets @Content-Type@ header to @image/{imgType}
+-- e.g. image/svg+xml
+image :: ByteString -> ByteString -> WebbyM appEnv ()
+image bs imgType = do
+  setHeader (hContentType, "image/" <> imgType)
+  raw bs
+
 -- | Send a binary stream in the response body. Also
 -- sets @Content-Type@ header to @application/octet-stream@
 blob :: ByteString -> WebbyM appEnv ()
 blob bs = do
   setHeader (hContentType, "application/octet-stream")
+  raw bs
+
+-- | Send a binary stream in the response body. Doesn't
+-- set @Content-Type@ header
+raw :: ByteString -> WebbyM appEnv ()
+raw bs = do
   wVar <- asksWEnv weResp
   Conc.modifyMVar_ wVar $
     \wr -> return $ wr {wrRespData = Right $ Bu.fromByteString bs}

--- a/webby.cabal
+++ b/webby.cabal
@@ -80,6 +80,7 @@ common base-settings
     , unliftio-core ==0.2.*
     , unordered-containers >=0.2.9 && <0.3
     , wai ==3.2.*
+    , mime-types ==0.1.*
 
   mixins:              base hiding (Prelude)
 


### PR DESCRIPTION
This function will send an image in the response body i.e. content type = `image/{image-type}`

It accepts two arguments
- `bs` the image content bytestring
- `imgType` the image type (e.g. `svg+xml`)

The `content-type` is set to `image/{imgType}` e.g. `image/svg+xml`

This will help in creating URLs that can directly render an image in the browser.